### PR TITLE
output time correction

### DIFF
--- a/docs/model_initialize_parameters_documentation.md
+++ b/docs/model_initialize_parameters_documentation.md
@@ -110,7 +110,7 @@ ModelParam =
                    albedo_wet_snow_t0: 15
                    albedo_dry_snow_t0: 30
                              albedo_K: 7
-                     output_frequency: "monthly"
+                     output_frequency: "all"
                        output_padding: 1000
                           column_ztop: 10
                          column_dztop: 0.0500

--- a/src/gemb.m
+++ b/src/gemb.m
@@ -78,14 +78,12 @@ function OutData = gemb(T, dz, d, W, re, gdn, gsp, a, a_diffuse, ClimateForcing,
 %% Example
 % Run a basic example: 
 %   
-%   % Initialize model parameters:
-%   ModelParam = model_initialize_parameters;
-%   
-%   ModelParam.output_frequency = "monthly"; 
-%   
 %   % Generate sample data: 
 %   time_step_hours = 3;
 %   ClimateForcing = simulate_climate_forcing("test_1", time_step_hours);
+%   
+%   % Initialize model parameters:
+%   ModelParam = model_initialize_parameters(output_frequency="daily");
 %   
 %   % Initialize grid:
 %   [T, dz, d, W, re, gdn, gsp, a, a_diffuse] = model_initialize_column(ModelParam, ClimateForcing);
@@ -330,7 +328,9 @@ function [output_index, OutData, OutCum] = model_initialize_output(column_length
         case "daily"
             output_index = (date_vector(1:end-1,3) - date_vector(2:end,3)) ~= 0;
         case "all"
-            output_index = true(length(date_vector)-1);
+            output_index = true(numel(ClimateForcing.daten),1);
+        otherwise
+            error('ModelParam.output_frequency can only be "monthly", "daily", or "all".')
     end
     
     % single level time series
@@ -341,12 +341,12 @@ function [output_index, OutData, OutCum] = model_initialize_output(column_length
     n = sum(output_index);
     
     % Set single level time series to NaNs:
-    OutData.time = ClimateForcing.daten(output_index)';
-    
     for v = 1:length(varname.monolevel)
         OutData.(varname.monolevel{v}) = nan(1,n);
     end
     
+    OutData.time = ClimateForcing.daten(output_index)';
+
     % Time averages/totals:
     I = find(output_index);                      % save index
     for i = 1:n

--- a/src/model_initialize_parameters.m
+++ b/src/model_initialize_parameters.m
@@ -267,7 +267,7 @@ arguments
     %   - "daily"
     %   - "all"
     options.output_frequency (1,1) string {mustBeMember(options.output_frequency, ...
-        ["all", "monthly", "daily"])} = 'monthly';
+        ["all", "monthly", "daily"])} = 'all';
 
     % number of additional vertical levels in output initialization to accommodate changing grid size
     options.output_padding  (1,1) double {mustBeInteger, mustBeInRange(options.output_padding, 0, 10000)} = 1000;   


### PR DESCRIPTION
Fixes an issue where indexing of `OutData.time` produced all NaNs. Also changing the default `ModelParam.output_frequency` to "all" because output timestamps should exactly match input timestamps unless the user explicitly requests lossy downsampling. Resolves #119.